### PR TITLE
Change link in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 
 * README
 ** What is it?
-   A minimal <a href="https://swriddle.github.io/tiimer/">HIIT timer</a>.
+   A minimal <a href="https://tiimer.app">HIIT timer</a>.
    
 ** Attributions
 


### PR DESCRIPTION
Use the TLD instead of the github.io-based URL.

References: 8